### PR TITLE
Service provider fix and...

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,6 +11,15 @@ class crowd::config {
     require => Class['crowd::install'],
   }
 
+  if($crowd::java_home == undef) {
+    fail('Please set a value for the java_home parameter.')
+  }
+  file {"${crowd::webappdir}/apache-tomcat/bin/setenv.sh":
+    ensure  => present,
+    content => template('crowd/setenv.sh.erb'),
+    mode    => '0755',
+  }
+
   file {"${crowd::webappdir}/crowd-webapp/WEB-INF/classes/crowd-init.properties":
     content => template('crowd/crowd-init.properties.erb'),
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,7 +57,10 @@ class crowd (
 
   # Misc Settings
   $downloadURL       = $crowd::params::downloadURL,
-  $service_provider  = $crowd::params::service_provider
+  $service_provider  = $crowd::params::service_provider,
+  $java_home         = $crowd::params::java_home,
+  $jvm_xms           = $crowd::params::jvm_xms,
+  $jvm_xmx           = $crowd::params::jvm_xmx
 ) inherits crowd::params {
 
   $webappdir    = "${installdir}/atlassian-${product}-${version}-standalone"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,7 +57,7 @@ class crowd (
 
   # Misc Settings
   $downloadURL       = $crowd::params::downloadURL,
-
+  $service_provider  = $crowd::params::service_provider
 ) inherits crowd::params {
 
   $webappdir    = "${installdir}/atlassian-${product}-${version}-standalone"

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -44,6 +44,8 @@ class crowd::install {
     target  => "${crowd::installdir}/atlassian-${crowd::product}-${crowd::version}-standalone",
     url     => $crowd::downloadURL,
     strip   => true,
+    owner   => $crowd::user,
+    group   => $crowd::group,
     notify  => Exec["chown_${crowd::webappdir}"],
   } ->
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -31,6 +31,8 @@ class crowd::install {
     init: {
       file { "/etc/init.d/crowd":
         ensure  => present,
+        owner   => 'root',
+        group   => 'root',
         content => template('crowd/etc/init.d/crowd.erb'),
         mode    => '0700'
       }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,10 @@ class crowd::params {
   $dbname           = 'crowd'
   $mavenrepopath    = 'http://repo1.maven.org/maven2/mysql/mysql-connector-java'
   $downloadURL      = 'http://www.atlassian.com/software/crowd/downloads/binary/'
+  $java_home        = undef
+  $jvm_xms          = '256m'
+  $jvm_xmx          = '512m'
+
   case $db {
     'mysql': {
       $dbport            = '3306'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,22 +1,23 @@
 # Class crowd::params
 #
 class crowd::params {
-  $version        = '2.7.0'
-  $user           = 'crowd'
-  $group          = 'crowd'
-  $product        = 'crowd'
-  $format         = 'tar.gz'
-  $installdir     = '/opt/crowd'
-  $homedir        = '/var/crowd-home'
-  $db             = 'mysql'
-  $dbuser         = 'crowdadm'
-  $dbpassword     = 'mypassword'
-  $dbserver       = 'localhost'
-  $dbname         = 'crowd'
-  $mavenrepopath  = 'http://repo1.maven.org/maven2/mysql/mysql-connector-java'
-  $downloadURL  = 'http://www.atlassian.com/software/crowd/downloads/binary/'
-
-case $db {
+  $version          = '2.7.0'
+  $user             = 'crowd'
+  $uid              = undef
+  $group            = 'crowd'
+  $product          = 'crowd'
+  $service_provider = 'upstart'
+  $format           = 'tar.gz'
+  $installdir       = '/opt/crowd'
+  $homedir          = '/var/crowd-home'
+  $db               = 'mysql'
+  $dbuser           = 'crowdadm'
+  $dbpassword       = 'mypassword'
+  $dbserver         = 'localhost'
+  $dbname           = 'crowd'
+  $mavenrepopath    = 'http://repo1.maven.org/maven2/mysql/mysql-connector-java'
+  $downloadURL      = 'http://www.atlassian.com/software/crowd/downloads/binary/'
+  case $db {
     'mysql': {
       $dbport            = '3306'
       $dbdriver          = 'com.mysql.jdbc.Driver'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,10 +1,9 @@
 # Class crowd::install
 #
 class crowd::service {
-
   service { 'crowd':
     ensure    => 'running',
-    provider  => 'upstart',
+    provider  => $crowd::service_provider,
     require   => Class['crowd::config'],
   }
 }

--- a/templates/etc/init.d/crowd.erb
+++ b/templates/etc/init.d/crowd.erb
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Crowd startup script
+#chkconfig: 2345 80 05
+#description: Crowd
+
+
+# Based on script at http://www.bifrost.org/problems.html
+
+RUN_AS_USER=<%= scope.lookupvar('crowd::user') %>
+CATALINA_HOME=<%= scope.lookupvar('crowd::webappdir') %>/apache-tomcat
+
+start() {
+        echo "Starting Crowd: "
+        if [ "x$USER" != "x$RUN_AS_USER" ]; then
+          su - $RUN_AS_USER -c "$CATALINA_HOME/bin/startup.sh"
+        else
+          $CATALINA_HOME/bin/startup.sh
+        fi
+        echo "done."
+}
+stop() {
+        echo "Shutting down Crowd: "
+        if [ "x$USER" != "x$RUN_AS_USER" ]; then
+          su - $RUN_AS_USER -c "$CATALINA_HOME/bin/shutdown.sh"
+        else
+          $CATALINA_HOME/bin/shutdown.sh
+        fi
+        echo "done."
+}
+
+case "$1" in
+  start)
+        start
+        ;;
+  stop)
+        stop
+        ;;
+  restart)
+        stop
+        sleep 10
+        #echo "Hard killing any remaining threads.."
+        #kill -9 `cat $CATALINA_HOME/work/catalina.pid`
+        start
+        ;;
+  *)
+        echo "Usage: $0 {start|stop|restart}"
+esac
+
+exit 0

--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -1,0 +1,5 @@
+JAVA_HOME="<%= scope.lookupvar('crowd::java_home') %>"
+JAVA_OPTS="-Xms<%= scope.lookupvar('crowd::jvm_xms') %> -Xmx<%= scope.lookupvar('crowd::jvm_xmx') %>  -XX:MaxPermSize=256m -Dfile.encoding=UTF-8 $JAVA_OPTS"
+
+export JAVA_HOME
+export JAVA_OPTS


### PR DESCRIPTION
- made the provider for the service 'crowd' ressource configurable and added a initscript for the _init_ provider.
- as of mkrakowitzer/puppet-deploy version 0.0.3 (forge.puppetlabs....) it seems to be that a user and group is specified for creating the deployment target. Cant say that because on github there are no taggings so i could not identify the 0.0.2 and so on. I also may be a change of puppet 3.6 and its default parameters for the file definition. 0072f38 fixes this by setting the user and group explicit at the deploy::file ressource. 
